### PR TITLE
feat: add sanctum support + API key management on profile page

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,16 @@ Local development is done using `docker compose`
 4. Build frontend: `npm run build`
 5. Start docker compose: `docker compose up`
 
+### ShareX Setup
+
+ShotShare is configured to work with [ShareX](https://getsharex.com/) a popular screenshot tool. Included in this repo is an [example configuration](/shotshare.sxcu) (`/shotshare.sxcu`). Below are a few instructions on how to get this running on your local install.
+
+1. On your ShotShare profile page (when logged in it will be at `{your installation}/profile`), create a new API key
+2. Copy the contents of `/shotshare.sxcu` into a notepad
+3. Replace `{Your ShotShare URL}` with your ShotShare installation URL, for example `https://demo.shotshare.mdsh.dev`
+4. Replace `{Your API Key}` with the API key you created in step #1
+5. In ShareX, click `Destinations -> Custom Uploader Settings -> Import -> `
+
 ## Contributing
 
 There is currently no established pattern for contributing, if you see something missing or feel like something could be better feel free to pop open an issue and/or PR.

--- a/app/Http/Controllers/ApiKeyController.php
+++ b/app/Http/Controllers/ApiKeyController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class ApiKeyController extends Controller
+{
+    public function store(Request $request)
+    {
+        $this->validate($request, [
+            'name' => ['string', 'sometimes', 'nullable'],
+        ]);
+
+        $token = $request->user()->createToken($request->get('name') ?? "Unnamed Key");
+
+        return response()->json([
+            'token' => $token->plainTextToken,
+        ]);
+    }
+
+    public function destroy(Request $request, string $id)
+    {
+        $request->user()->tokens()->whereId($id)->delete();
+
+        return response(status: 204);
+    }
+}

--- a/app/Http/Controllers/ApiKeyController.php
+++ b/app/Http/Controllers/ApiKeyController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 
 class ApiKeyController extends Controller
 {
@@ -23,6 +24,6 @@ class ApiKeyController extends Controller
     {
         $request->user()->tokens()->whereId($id)->delete();
 
-        return response(status: 204);
+        return response(status: Response::HTTP_NO_CONTENT);
     }
 }

--- a/app/Http/Controllers/ApiKeyController.php
+++ b/app/Http/Controllers/ApiKeyController.php
@@ -12,7 +12,7 @@ class ApiKeyController extends Controller
             'name' => ['string', 'sometimes', 'nullable'],
         ]);
 
-        $token = $request->user()->createToken($request->get('name') ?? "Unnamed Key");
+        $token = $request->user()->createToken($request->get('name') ?? 'Unnamed Key');
 
         return response()->json([
             'token' => $token->plainTextToken,

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -21,6 +21,7 @@ class ProfileController extends Controller
         return Inertia::render('Profile/Edit', [
             'mustVerifyEmail' => $request->user() instanceof MustVerifyEmail,
             'status' => session('status'),
+            'apiKeys' => $request->user()->tokens
         ]);
     }
 

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -21,7 +21,7 @@ class ProfileController extends Controller
         return Inertia::render('Profile/Edit', [
             'mustVerifyEmail' => $request->user() instanceof MustVerifyEmail,
             'status' => session('status'),
-            'apiKeys' => $request->user()->tokens
+            'apiKeys' => $request->user()->tokens,
         ]);
     }
 

--- a/app/Http/Controllers/ShotController.php
+++ b/app/Http/Controllers/ShotController.php
@@ -34,12 +34,11 @@ class ShotController extends Controller
 
     public function show(Request $request, string $id)
     {
-        $shot = (config('features.uuid_routes')
-            ? Shot::whereUuid($id)
-            : Shot::whereId($id))->firstOrFail();
+        $shot = Shot::wherePublicIdentifier($id)->firstOrFail();
 
         if ($shot->parent_shot_id) {
             $parentShotId = config('features.uuid_routes')
+                // TODO: Don't load parent (perhaps migrate parent_shot_id to be either uuid or id pending settings)
                 ? $shot->parentShot->uuid
                 : $shot->parent_shot_id;
 

--- a/app/Http/Controllers/UploadController.php
+++ b/app/Http/Controllers/UploadController.php
@@ -31,8 +31,8 @@ class UploadController extends Controller
         if ($request->expectsJson()) {
             return response()->json([
                 'data' => [
-                    'link' => route('shots.show', $id)
-                ]
+                    'link' => route('shots.show', $id),
+                ],
             ]);
         }
 

--- a/app/Http/Controllers/UploadController.php
+++ b/app/Http/Controllers/UploadController.php
@@ -24,8 +24,18 @@ class UploadController extends Controller
             }
         }
 
-        return to_route('shots.show', config('features.uuid_routes')
+        $id = config('features.uuid_routes')
             ? $parentShot?->uuid
-            : $parentShot?->getKey());
+            : $parentShot?->getKey();
+
+        if ($request->expectsJson()) {
+            return response()->json([
+                'data' => [
+                    'link' => route('shots.show', $id)
+                ]
+            ]);
+        }
+
+        return to_route('shots.show', $id);
     }
 }

--- a/app/Http/Controllers/UploadController.php
+++ b/app/Http/Controllers/UploadController.php
@@ -24,9 +24,7 @@ class UploadController extends Controller
             }
         }
 
-        $id = config('features.uuid_routes')
-            ? $parentShot?->uuid
-            : $parentShot?->getKey();
+        $id = $parentShot->publicIdentifier;
 
         if ($request->expectsJson()) {
             return response()->json([

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -41,7 +41,7 @@ class Kernel extends HttpKernel
         ],
 
         'api' => [
-            // \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
+            \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
             \Illuminate\Routing\Middleware\ThrottleRequests::class.':api',
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],

--- a/app/Models/PersonalAccessToken.php
+++ b/app/Models/PersonalAccessToken.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Laravel\Sanctum\PersonalAccessToken as SanctumPersonalAccessToken;
+
+class PersonalAccessToken extends SanctumPersonalAccessToken
+{
+    protected $fillable = [
+        'name',
+        'token',
+        'anonymized_token',
+        'abilities',
+        'expires_at',
+    ];
+}

--- a/app/Models/PersonalAccessToken.php
+++ b/app/Models/PersonalAccessToken.php
@@ -2,8 +2,6 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
 use Laravel\Sanctum\PersonalAccessToken as SanctumPersonalAccessToken;
 
 class PersonalAccessToken extends SanctumPersonalAccessToken

--- a/app/Models/Shot.php
+++ b/app/Models/Shot.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -43,12 +44,28 @@ class Shot extends Model
     {
         return Attribute::make(
             get: fn ($_, array $attributes) => [
-                'url' => config('features.uuid_routes')
-                    ? route('shots.show', $attributes['uuid'])
-                    : route('shots.show', $attributes['id']),
+                'url' => route('shots.show', $this->publicIdentifier),
                 'asset_url' => asset($attributes['path']),
             ],
         );
+    }
+
+    protected function publicIdentifier(): Attribute
+    {
+        return Attribute::make(
+            get: fn ($_, array $attributes) => config('features.uuid_routes')
+                ? $attributes['uuid']
+                : $attributes['id'],
+        );
+    }
+
+    public function scopeWherePublicIdentifier(Builder $query, string|int $id): void
+    {
+        if (config('features.uuid_routes')) {
+            $query->whereUuid($id);
+        } else {
+            $query->whereId($id);
+        }
     }
 
     public function user(): BelongsTo

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -9,9 +9,9 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Str;
 use Laravel\Sanctum\HasApiTokens;
 use Laravel\Sanctum\NewAccessToken;
-use Illuminate\Support\Str;
 
 class User extends Authenticatable
 {
@@ -48,14 +48,14 @@ class User extends Authenticatable
         'password' => 'hashed',
     ];
 
-    public function createToken(string $name, array $abilities = ['*'], DateTimeInterface $expiresAt = null)
+    public function createToken(string $name, array $abilities = ['*'], ?DateTimeInterface $expiresAt = null)
     {
         $plainTextToken = $this->generateTokenString();
 
         $token = $this->tokens()->create([
             'name' => $name,
             'token' => hash('sha256', $plainTextToken),
-            'anonymized_token' => Str::mask($plainTextToken, "•", "5"),
+            'anonymized_token' => Str::mask($plainTextToken, '•', '5'),
             'abilities' => $abilities,
             'expires_at' => $expiresAt,
         ]);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,11 +3,15 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+
+use DateTimeInterface;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
+use Laravel\Sanctum\NewAccessToken;
+use Illuminate\Support\Str;
 
 class User extends Authenticatable
 {
@@ -43,6 +47,21 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
         'password' => 'hashed',
     ];
+
+    public function createToken(string $name, array $abilities = ['*'], DateTimeInterface $expiresAt = null)
+    {
+        $plainTextToken = $this->generateTokenString();
+
+        $token = $this->tokens()->create([
+            'name' => $name,
+            'token' => hash('sha256', $plainTextToken),
+            'anonymized_token' => Str::mask($plainTextToken, "•", "5"),
+            'abilities' => $abilities,
+            'expires_at' => $expiresAt,
+        ]);
+
+        return new NewAccessToken($token, $plainTextToken);
+    }
 
     public function shots(): HasMany
     {

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -3,7 +3,10 @@
 namespace App\Providers;
 
 // use Illuminate\Support\Facades\Gate;
+
+use App\Models\PersonalAccessToken;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use Laravel\Sanctum\Sanctum;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -21,6 +24,6 @@ class AuthServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Sanctum::usePersonalAccessTokenModel(PersonalAccessToken::class);
     }
 }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -31,6 +31,7 @@ class RouteServiceProvider extends ServiceProvider
         $this->routes(function () {
             Route::middleware('api')
                 ->prefix('api')
+                ->name('api.')
                 ->group(base_path('routes/api.php'));
 
             Route::middleware('web')

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "inertiajs/inertia-laravel": "^0.6.8",
         "laravel/framework": "^10.10",
         "laravel/prompts": "^0.1.14",
-        "laravel/sanctum": "^3.2",
+        "laravel/sanctum": "^3.3",
         "laravel/tinker": "^2.8",
         "tightenco/ziggy": "^1.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9b099d04771fd48975e80b35616ff2c6",
+    "content-hash": "28bfe1f68f5ca1cf1b2d7322b0b1e5fd",
     "packages": [
         {
             "name": "brick/math",

--- a/database/migrations/2024_01_15_215829_update_personal_access_tokens_add_anonymized_column.php
+++ b/database/migrations/2024_01_15_215829_update_personal_access_tokens_add_anonymized_column.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('personal_access_tokens', function (Blueprint $table) {
-            $table->string("anonymized_token")->nullable()->after("token");
+            $table->string('anonymized_token')->nullable()->after('token');
         });
     }
 
@@ -22,7 +22,7 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('personal_access_tokens', function (Blueprint $table) {
-            $table->dropColumn("anonymized_token");
+            $table->dropColumn('anonymized_token');
         });
     }
 };

--- a/database/migrations/2024_01_15_215829_update_personal_access_tokens_add_anonymized_column.php
+++ b/database/migrations/2024_01_15_215829_update_personal_access_tokens_add_anonymized_column.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('personal_access_tokens', function (Blueprint $table) {
+            $table->string("anonymized_token")->nullable()->after("token");
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('personal_access_tokens', function (Blueprint $table) {
+            $table->dropColumn("anonymized_token");
+        });
+    }
+};

--- a/resources/js/Components/ui/Spinner.vue
+++ b/resources/js/Components/ui/Spinner.vue
@@ -1,0 +1,10 @@
+<script setup>
+
+</script>
+
+<template>
+    <svg class="animate-spin h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+    </svg>
+</template>

--- a/resources/js/Components/ui/TimeAgo.vue
+++ b/resources/js/Components/ui/TimeAgo.vue
@@ -1,0 +1,33 @@
+<script setup>
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger
+} from '@/Components/ui/tooltip'
+import { format } from 'timeago.js'
+
+defineProps({
+    datetime: String
+})
+</script>
+
+<template>
+    <template v-if="datetime">
+        <TooltipProvider>
+            <Tooltip>
+                <TooltipTrigger>
+                    {{ format(datetime) }}
+                </TooltipTrigger>
+                <TooltipContent>
+                    {{ datetime }}
+                </TooltipContent>
+            </Tooltip>
+        </TooltipProvider>
+    </template>
+    <template v-else>
+        <slot name="empty-state">
+            <span class="text-gray-500">--</span>
+        </slot>
+    </template>
+</template>

--- a/resources/js/Components/ui/dialog/Dialog.vue
+++ b/resources/js/Components/ui/dialog/Dialog.vue
@@ -1,0 +1,18 @@
+<script setup>
+import { DialogRoot, useForwardPropsEmits } from "radix-vue";
+
+const props = defineProps({
+  open: { type: Boolean, required: false },
+  defaultOpen: { type: Boolean, required: false },
+  modal: { type: Boolean, required: false },
+});
+const emits = defineEmits(["update:open"]);
+
+const forwarded = useForwardPropsEmits(props, emits);
+</script>
+
+<template>
+  <DialogRoot v-bind="forwarded">
+    <slot />
+  </DialogRoot>
+</template>

--- a/resources/js/Components/ui/dialog/DialogClose.vue
+++ b/resources/js/Components/ui/dialog/DialogClose.vue
@@ -1,0 +1,14 @@
+<script setup>
+import { DialogClose } from "radix-vue";
+
+const props = defineProps({
+  asChild: { type: Boolean, required: false },
+  as: { type: null, required: false },
+});
+</script>
+
+<template>
+  <DialogClose v-bind="props">
+    <slot />
+  </DialogClose>
+</template>

--- a/resources/js/Components/ui/dialog/DialogContent.vue
+++ b/resources/js/Components/ui/dialog/DialogContent.vue
@@ -1,0 +1,57 @@
+<script setup>
+import {
+  DialogClose,
+  DialogContent,
+  DialogOverlay,
+  DialogPortal,
+  useEmitAsProps,
+} from "radix-vue";
+import { X } from "lucide-vue-next";
+import { cn } from "@/lib/utils";
+
+const props = defineProps({
+  forceMount: { type: Boolean, required: false },
+  trapFocus: { type: Boolean, required: false },
+  disableOutsidePointerEvents: { type: Boolean, required: false },
+  asChild: { type: Boolean, required: false },
+  as: { type: null, required: false },
+  class: { type: String, required: false },
+});
+const emits = defineEmits([
+  "escapeKeyDown",
+  "pointerDownOutside",
+  "focusOutside",
+  "interactOutside",
+  "dismiss",
+  "openAutoFocus",
+  "closeAutoFocus",
+]);
+
+const emitsAsProps = useEmitAsProps(emits);
+</script>
+
+<template>
+  <DialogPortal>
+    <DialogOverlay
+      class="fixed inset-0 z-50 bg-background/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
+    />
+    <DialogContent
+      :class="
+        cn(
+          'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg md:w-full',
+          props.class
+        )
+      "
+      v-bind="{ ...props, ...emitsAsProps }"
+    >
+      <slot />
+
+      <DialogClose
+        class="absolute top-3 right-3 p-0.5 transition-colors rounded-md hover:bg-secondary"
+      >
+        <X class="w-4 h-4" />
+        <span class="sr-only">Close</span>
+      </DialogClose>
+    </DialogContent>
+  </DialogPortal>
+</template>

--- a/resources/js/Components/ui/dialog/DialogDescription.vue
+++ b/resources/js/Components/ui/dialog/DialogDescription.vue
@@ -1,0 +1,19 @@
+<script setup>
+import { DialogDescription } from "radix-vue";
+import { cn } from "@/lib/utils";
+
+const props = defineProps({
+  asChild: { type: Boolean, required: false },
+  as: { type: null, required: false },
+  class: { type: String, required: false },
+});
+</script>
+
+<template>
+  <DialogDescription
+    v-bind="props"
+    :class="cn('text-muted-foreground text-sm', props.class)"
+  >
+    <slot />
+  </DialogDescription>
+</template>

--- a/resources/js/Components/ui/dialog/DialogFooter.vue
+++ b/resources/js/Components/ui/dialog/DialogFooter.vue
@@ -1,0 +1,20 @@
+<script setup>
+import { cn } from "@/lib/utils";
+
+const props = defineProps({
+  class: { type: String, required: false },
+});
+</script>
+
+<template>
+  <div
+    :class="
+      cn(
+        'flex flex-col space-y-2 sm:space-y-0 mt-1.5 sm:flex-row sm:justify-end sm:space-x-2',
+        props.class
+      )
+    "
+  >
+    <slot />
+  </div>
+</template>

--- a/resources/js/Components/ui/dialog/DialogHeader.vue
+++ b/resources/js/Components/ui/dialog/DialogHeader.vue
@@ -1,0 +1,15 @@
+<script setup>
+import { cn } from "@/lib/utils";
+
+const props = defineProps({
+  class: { type: String, required: false },
+});
+</script>
+
+<template>
+  <div
+    :class="cn('flex flex-col space-y-2 text-center sm:text-left', props.class)"
+  >
+    <slot />
+  </div>
+</template>

--- a/resources/js/Components/ui/dialog/DialogTitle.vue
+++ b/resources/js/Components/ui/dialog/DialogTitle.vue
@@ -1,0 +1,24 @@
+<script setup>
+import { DialogTitle } from "radix-vue";
+import { cn } from "@/lib/utils";
+
+const props = defineProps({
+  asChild: { type: Boolean, required: false },
+  as: { type: null, required: false },
+  class: { type: String, required: false },
+});
+</script>
+
+<template>
+  <DialogTitle
+    v-bind="props"
+    :class="
+      cn(
+        'text-lg text-foreground font-semibold leading-none tracking-tight',
+        props.class
+      )
+    "
+  >
+    <slot />
+  </DialogTitle>
+</template>

--- a/resources/js/Components/ui/dialog/DialogTrigger.vue
+++ b/resources/js/Components/ui/dialog/DialogTrigger.vue
@@ -1,0 +1,14 @@
+<script setup>
+import { DialogTrigger } from "radix-vue";
+
+const props = defineProps({
+  asChild: { type: Boolean, required: false },
+  as: { type: null, required: false },
+});
+</script>
+
+<template>
+  <DialogTrigger v-bind="props">
+    <slot />
+  </DialogTrigger>
+</template>

--- a/resources/js/Components/ui/dialog/index.js
+++ b/resources/js/Components/ui/dialog/index.js
@@ -1,0 +1,8 @@
+export { default as Dialog } from "./Dialog.vue";
+export { default as DialogClose } from "./DialogClose.vue";
+export { default as DialogTrigger } from "./DialogTrigger.vue";
+export { default as DialogHeader } from "./DialogHeader.vue";
+export { default as DialogTitle } from "./DialogTitle.vue";
+export { default as DialogDescription } from "./DialogDescription.vue";
+export { default as DialogContent } from "./DialogContent.vue";
+export { default as DialogFooter } from "./DialogFooter.vue";

--- a/resources/js/Components/ui/form/FormControl.vue
+++ b/resources/js/Components/ui/form/FormControl.vue
@@ -1,0 +1,9 @@
+<script setup>
+import { Slot } from "radix-vue";
+</script>
+
+<template>
+  <Slot>
+    <slot />
+  </Slot>
+</template>

--- a/resources/js/Components/ui/form/FormDescription.vue
+++ b/resources/js/Components/ui/form/FormDescription.vue
@@ -1,0 +1,19 @@
+<script setup>
+import { useAttrs } from "vue";
+import { cn } from "@/lib/utils";
+
+defineOptions({
+  inheritAttrs: false,
+});
+
+const { class: className, ...rest } = useAttrs();
+</script>
+
+<template>
+  <p
+    :class="cn('text-sm text-muted-foreground', className ?? '')"
+    v-bind="rest"
+  >
+    <slot />
+  </p>
+</template>

--- a/resources/js/Components/ui/form/FormItem.vue
+++ b/resources/js/Components/ui/form/FormItem.vue
@@ -1,0 +1,24 @@
+<script>
+export const FORM_ITEM_INJECTION_KEY = Symbol();
+</script>
+
+<script setup>
+import { provide, useAttrs } from "vue";
+import { useId } from "radix-vue";
+import { cn } from "@/lib/utils";
+
+defineOptions({
+  inheritAttrs: false,
+});
+
+const id = useId();
+provide(FORM_ITEM_INJECTION_KEY, id);
+
+const { class: className, ...rest } = useAttrs();
+</script>
+
+<template>
+  <div :class="cn('space-y-2', className ?? '')" v-bind="rest">
+    <slot />
+  </div>
+</template>

--- a/resources/js/Components/ui/form/FormLabel.vue
+++ b/resources/js/Components/ui/form/FormLabel.vue
@@ -1,0 +1,31 @@
+<script setup>
+import { useAttrs, onUpdated } from "vue";
+import { Label } from "radix-vue";
+import { cn } from "@/lib/utils";
+
+defineOptions({
+  inheritAttrs: false,
+});
+const props = defineProps({
+  asChild: { type: Boolean, required: false },
+  as: { type: null, required: false },
+  invalid: { type: Boolean, default: false }
+});
+
+const { class: className, ...rest } = useAttrs();
+</script>
+
+<template>
+    <Label
+        :class="
+        cn(
+            'block text-sm tracking-tight font-medium text-left',
+            invalid ? 'text-destructive' : 'text-foreground',
+            className ?? ''
+        )
+        "
+        v-bind="rest"
+    >
+        <slot />
+    </Label>
+</template>

--- a/resources/js/Components/ui/form/FormMessage.vue
+++ b/resources/js/Components/ui/form/FormMessage.vue
@@ -1,0 +1,8 @@
+<script setup>
+</script>
+
+<template>
+    <p class="text-sm font-medium text-destructive">
+        <slot/>
+    </p>
+</template>

--- a/resources/js/Components/ui/form/index.js
+++ b/resources/js/Components/ui/form/index.js
@@ -1,0 +1,5 @@
+export { default as FormItem } from "./FormItem.vue";
+export { default as FormLabel } from "./FormLabel.vue";
+export { default as FormControl } from "./FormControl.vue";
+export { default as FormMessage } from "./FormMessage.vue";
+export { default as FormDescription } from "./FormDescription.vue";

--- a/resources/js/Components/ui/table/Table.vue
+++ b/resources/js/Components/ui/table/Table.vue
@@ -1,0 +1,15 @@
+<script setup>
+import { cn } from "@/lib/utils";
+
+const props = defineProps({
+  class: { type: String, required: false },
+});
+</script>
+
+<template>
+  <div class="w-full overflow-auto">
+    <table :class="cn('w-full caption-bottom text-sm', props.class)">
+      <slot />
+    </table>
+  </div>
+</template>

--- a/resources/js/Components/ui/table/TableBody.vue
+++ b/resources/js/Components/ui/table/TableBody.vue
@@ -1,0 +1,13 @@
+<script setup>
+import { cn } from "@/lib/utils";
+
+const props = defineProps({
+  class: { type: String, required: false },
+});
+</script>
+
+<template>
+  <tbody :class="cn('[&_tr:last-child]:border-0', props.class)">
+    <slot />
+  </tbody>
+</template>

--- a/resources/js/Components/ui/table/TableCaption.vue
+++ b/resources/js/Components/ui/table/TableCaption.vue
@@ -1,0 +1,13 @@
+<script setup>
+import { cn } from "@/lib/utils";
+
+const props = defineProps({
+  class: { type: String, required: false },
+});
+</script>
+
+<template>
+  <caption :class="cn('mt-4 text-sm text-muted-foreground', props.class)">
+    <slot />
+  </caption>
+</template>

--- a/resources/js/Components/ui/table/TableCell.vue
+++ b/resources/js/Components/ui/table/TableCell.vue
@@ -1,0 +1,15 @@
+<script setup>
+import { cn } from "@/lib/utils";
+
+const props = defineProps({
+  class: { type: String, required: false },
+});
+</script>
+
+<template>
+  <td
+    :class="cn('p-4 align-middle [&:has([role=checkbox])]:pr-0', props.class)"
+  >
+    <slot />
+  </td>
+</template>

--- a/resources/js/Components/ui/table/TableEmpty.vue
+++ b/resources/js/Components/ui/table/TableEmpty.vue
@@ -1,0 +1,28 @@
+<script setup>
+import TableRow from "./TableRow.vue";
+import TableCell from "./TableCell.vue";
+import { cn } from "@/lib/utils";
+
+const props = defineProps({
+  class: { type: String, required: false, default: "" },
+  colspan: { type: Number, required: false, default: 1 },
+});
+</script>
+
+<template>
+  <TableRow>
+    <TableCell
+      :class="
+        cn(
+          'p-4 whitespace-nowrap align-middle text-sm text-foreground',
+          props.class
+        )
+      "
+      :colspan="props.colspan"
+    >
+      <div class="flex items-center justify-center py-10">
+        <slot />
+      </div>
+    </TableCell>
+  </TableRow>
+</template>

--- a/resources/js/Components/ui/table/TableFooter.vue
+++ b/resources/js/Components/ui/table/TableFooter.vue
@@ -1,0 +1,15 @@
+<script setup>
+import { cn } from "@/lib/utils";
+
+const props = defineProps({
+  class: { type: String, required: false },
+});
+</script>
+
+<template>
+  <tfoot
+    :class="cn('bg-primary font-medium text-primary-foreground', props.class)"
+  >
+    <slot />
+  </tfoot>
+</template>

--- a/resources/js/Components/ui/table/TableHead.vue
+++ b/resources/js/Components/ui/table/TableHead.vue
@@ -1,0 +1,20 @@
+<script setup>
+import { cn } from "@/lib/utils";
+
+const props = defineProps({
+  class: { type: String, required: false },
+});
+</script>
+
+<template>
+  <th
+    :class="
+      cn(
+        'h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0',
+        props.class
+      )
+    "
+  >
+    <slot />
+  </th>
+</template>

--- a/resources/js/Components/ui/table/TableHeader.vue
+++ b/resources/js/Components/ui/table/TableHeader.vue
@@ -1,0 +1,13 @@
+<script setup>
+import { cn } from "@/lib/utils";
+
+const props = defineProps({
+  class: { type: String, required: false },
+});
+</script>
+
+<template>
+  <thead :class="cn('[&_tr]:border-b', props.class)">
+    <slot />
+  </thead>
+</template>

--- a/resources/js/Components/ui/table/TableRow.vue
+++ b/resources/js/Components/ui/table/TableRow.vue
@@ -1,0 +1,20 @@
+<script setup>
+import { cn } from "@/lib/utils";
+
+const props = defineProps({
+  class: { type: String, required: false },
+});
+</script>
+
+<template>
+  <tr
+    :class="
+      cn(
+        'border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted',
+        props.class
+      )
+    "
+  >
+    <slot />
+  </tr>
+</template>

--- a/resources/js/Components/ui/table/index.js
+++ b/resources/js/Components/ui/table/index.js
@@ -1,0 +1,8 @@
+export { default as Table } from "./Table.vue";
+export { default as TableBody } from "./TableBody.vue";
+export { default as TableCell } from "./TableCell.vue";
+export { default as TableHead } from "./TableHead.vue";
+export { default as TableHeader } from "./TableHeader.vue";
+export { default as TableRow } from "./TableRow.vue";
+export { default as TableCaption } from "./TableCaption.vue";
+export { default as TableEmpty } from "./TableEmpty.vue";

--- a/resources/js/Components/ui/tooltip/Tooltip.vue
+++ b/resources/js/Components/ui/tooltip/Tooltip.vue
@@ -1,0 +1,20 @@
+<script setup>
+import { TooltipRoot, useForwardPropsEmits } from "radix-vue";
+
+const props = defineProps({
+  defaultOpen: { type: Boolean, required: false },
+  open: { type: Boolean, required: false },
+  delayDuration: { type: Number, required: false },
+  disableHoverableContent: { type: Boolean, required: false },
+  disableClosingTrigger: { type: Boolean, required: false },
+});
+const emits = defineEmits(["update:open"]);
+
+const forwarded = useForwardPropsEmits(props, emits);
+</script>
+
+<template>
+  <TooltipRoot v-bind="forwarded">
+    <slot />
+  </TooltipRoot>
+</template>

--- a/resources/js/Components/ui/tooltip/TooltipContent.vue
+++ b/resources/js/Components/ui/tooltip/TooltipContent.vue
@@ -1,0 +1,39 @@
+<script setup>
+import { TooltipContent, TooltipPortal, useForwardPropsEmits } from "radix-vue";
+import { cn } from "@/lib/utils";
+
+const props = defineProps({
+  ariaLabel: { type: String, required: false },
+  asChild: { type: Boolean, required: false },
+  as: { type: null, required: false },
+  side: { type: null, required: false },
+  sideOffset: { type: Number, required: false, default: 4 },
+  align: { type: null, required: false },
+  alignOffset: { type: Number, required: false },
+  avoidCollisions: { type: Boolean, required: false },
+  collisionBoundary: { type: null, required: false },
+  collisionPadding: { type: [Number, Object], required: false },
+  arrowPadding: { type: Number, required: false },
+  sticky: { type: String, required: false },
+  hideWhenDetached: { type: Boolean, required: false },
+});
+const emits = defineEmits(["escapeKeyDown", "pointerDownOutside"]);
+
+const forwarded = useForwardPropsEmits(props, emits);
+</script>
+
+<template>
+  <TooltipPortal>
+    <TooltipContent
+      v-bind="{ ...forwarded, ...$attrs }"
+      :class="
+        cn(
+          'z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+          $attrs.class ?? ''
+        )
+      "
+    >
+      <slot />
+    </TooltipContent>
+  </TooltipPortal>
+</template>

--- a/resources/js/Components/ui/tooltip/TooltipProvider.vue
+++ b/resources/js/Components/ui/tooltip/TooltipProvider.vue
@@ -1,0 +1,16 @@
+<script setup>
+import { TooltipProvider } from "radix-vue";
+
+const props = defineProps({
+  delayDuration: { type: Number, required: false },
+  skipDelayDuration: { type: Number, required: false },
+  disableHoverableContent: { type: Boolean, required: false },
+  disableClosingTrigger: { type: Boolean, required: false },
+});
+</script>
+
+<template>
+  <TooltipProvider v-bind="props">
+    <slot />
+  </TooltipProvider>
+</template>

--- a/resources/js/Components/ui/tooltip/TooltipTrigger.vue
+++ b/resources/js/Components/ui/tooltip/TooltipTrigger.vue
@@ -1,0 +1,14 @@
+<script setup>
+import { TooltipTrigger } from "radix-vue";
+
+const props = defineProps({
+  asChild: { type: Boolean, required: false },
+  as: { type: null, required: false },
+});
+</script>
+
+<template>
+  <TooltipTrigger v-bind="props">
+    <slot />
+  </TooltipTrigger>
+</template>

--- a/resources/js/Components/ui/tooltip/index.js
+++ b/resources/js/Components/ui/tooltip/index.js
@@ -1,0 +1,4 @@
+export { default as Tooltip } from "./Tooltip.vue";
+export { default as TooltipContent } from "./TooltipContent.vue";
+export { default as TooltipTrigger } from "./TooltipTrigger.vue";
+export { default as TooltipProvider } from "./TooltipProvider.vue";

--- a/resources/js/Pages/Profile/Edit.vue
+++ b/resources/js/Pages/Profile/Edit.vue
@@ -3,6 +3,7 @@ import Layout from '@/Layouts/Layout.vue';
 import DeleteUserForm from './Partials/DeleteUserForm.vue';
 import UpdatePasswordForm from './Partials/UpdatePasswordForm.vue';
 import UpdateProfileInformationForm from './Partials/UpdateProfileInformationForm.vue';
+import CardApiKeys from './Partials/CardApiKeys.vue';
 import { Head } from '@inertiajs/vue3';
 import {
     Card,
@@ -14,6 +15,7 @@ import {
 } from '@/Components/ui/card'
 
 defineProps({
+    apiKeys: Array,
     mustVerifyEmail: {
         type: Boolean,
     },
@@ -41,7 +43,6 @@ defineProps({
                     <UpdateProfileInformationForm
                         :must-verify-email="mustVerifyEmail"
                         :status="status"
-                        class="max-w-xl"
                     />
                 </CardContent>
             </Card>
@@ -52,9 +53,11 @@ defineProps({
                     <CardDescription>Ensure your account is using a long, random password to stay secure.</CardDescription>
                 </CardHeader>
                 <CardContent>
-                    <UpdatePasswordForm class="max-w-xl" />
+                    <UpdatePasswordForm />
                 </CardContent>
             </Card>
+
+            <CardApiKeys :api-keys="apiKeys"/>
 
             <Card>
                 <CardHeader>
@@ -62,7 +65,7 @@ defineProps({
                     <CardDescription>Once your account is deleted, all of its resources and data will be permanently deleted. Before deleting your account, please download any data or information that you wish to retain.</CardDescription>
                 </CardHeader>
                 <CardContent>
-                    <DeleteUserForm class="max-w-xl" />
+                    <DeleteUserForm />
                 </CardContent>
             </Card>
         </div>

--- a/resources/js/Pages/Profile/Partials/CardApiKeys.vue
+++ b/resources/js/Pages/Profile/Partials/CardApiKeys.vue
@@ -1,0 +1,139 @@
+<script setup>
+import { Button } from '@/Components/ui/button'
+import { router } from '@inertiajs/vue3';
+import { TrashIcon } from "@heroicons/vue/24/outline";
+import Spinner from '@/Components/ui/Spinner.vue'
+import TimeAgo from '@/Components/ui/TimeAgo.vue'
+import RequireConfirmationDialog from '@/Components/RequireConfirmationDialog.vue'
+import DialogCreateApiKey from '@/Pages/Profile/Partials/DialogCreateApiKey.vue'
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardFooter,
+    CardHeader,
+    CardTitle,
+} from '@/Components/ui/card'
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@/Components/ui/table'
+
+defineProps({
+    apiKeys: Array,
+})
+
+const deleteApiKey = (apiKeyId) => {
+    return axios.delete(route('api-keys.destroy', apiKeyId))
+        .catch((err) => {
+            console.error("Failed to delete API key")
+            console.error(err)
+        })
+        .finally(() => {
+            router.reload({only: [
+                'apiKeys',
+            ]})
+        })
+}
+</script>
+
+<template>
+    <Card>
+        <CardHeader>
+            <CardTitle>API Keys</CardTitle>
+            <CardDescription>Manage keys used for programmatic access to ShotShare.</CardDescription>
+        </CardHeader>
+        <CardContent>
+            <section class="space-y-6">
+                <DialogCreateApiKey>
+                    <Button>
+                        Create API Key
+                    </Button>
+                </DialogCreateApiKey>
+
+                <Table>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead>Name</TableHead>
+                            <TableHead>API Key</TableHead>
+                            <TableHead>Created</TableHead>
+                            <TableHead>Last Used</TableHead>
+                            <!-- Actions -->
+                            <TableHead/>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        <TableRow
+                            v-for="apiKey in apiKeys"
+                            :key="apiKey.id">
+                            <TableCell>
+                                {{apiKey.name}}
+                            </TableCell>
+
+                            <TableCell>
+                                <p class="truncate max-w-[125px]">
+                                    {{apiKey.anonymized_token}}
+                                </p>
+                            </TableCell>
+
+                            <TableCell>
+                                <TimeAgo :datetime="apiKey.created_at"/>
+                            </TableCell>
+
+                            <TableCell>
+                                <TimeAgo :datetime="apiKey.last_used_at">
+                                    <template #empty-state>
+                                        <p class="text-gray-500 italic">Never</p>
+                                    </template>
+                                </TimeAgo>
+                            </TableCell>
+
+                            <TableCell align="end" class="flex items-center justify-end">
+                                <RequireConfirmationDialog :action="() => deleteApiKey(apiKey.id)">
+                                    <template #title>
+                                        Are you sure you wish to delete this API key?
+                                    </template>
+
+                                    <template #description>
+                                        Deleting API keys is a destructive action. You will not be able to recover this key if you delete it.
+                                    </template>
+
+                                    <template #reject>
+                                        Cancel
+                                    </template>
+
+                                    <template #confirm>
+                                        Delete API Key
+                                    </template>
+
+                                    <button class="text-gray-500 hover:text-destructive transition flex items-center justify-center">
+                                        <TrashIcon class="h-6 w-6" />
+                                    </button>
+                                </RequireConfirmationDialog>
+                            </TableCell>
+                        </TableRow>
+
+                        <!-- Empty State -->
+                        <TableRow v-if="apiKeys === undefined">
+                            <TableCell :colSpan="5" class="h-36">
+                                <div class="w-full h-full flex items-center justify-center">
+                                    <Spinner/>
+                                </div>
+                            </TableCell>
+                        </TableRow>
+
+                        <TableRow v-else-if="!apiKeys?.length">
+                            <TableCell :colSpan="5" class="h-36 text-center">
+                                <h3 class="font-semibold">No API keys exist</h3>
+                            </TableCell>
+                        </TableRow>
+                    </TableBody>
+                </Table>
+            </section>
+        </CardContent>
+    </Card>
+</template>

--- a/resources/js/Pages/Profile/Partials/DialogCreateApiKey.vue
+++ b/resources/js/Pages/Profile/Partials/DialogCreateApiKey.vue
@@ -1,0 +1,139 @@
+<script setup>
+import { ref } from 'vue'
+import { router } from '@inertiajs/vue3'
+import { Button } from '@/Components/ui/button'
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from '@/Components/ui/dialog'
+import { Input } from '@/Components/ui/input'
+import {
+    FormControl,
+    FormDescription,
+    FormItem,
+    FormLabel,
+    FormMessage,
+} from '@/Components/ui/form'
+import axios from 'axios'
+import { Label } from '@/Components/ui/label'
+import { UseClipboard } from '@vueuse/components'
+import { ClipboardIcon, CheckIcon } from "@heroicons/vue/24/outline"
+import { watch } from 'vue'
+
+const open = ref(false)
+
+const form = ref({
+    name: "",
+})
+
+const errors = ref({
+    name: null
+})
+
+const token = ref(null)
+
+watch(open, () => {
+    if(!open.value) {
+        token.value = null
+    }
+})
+
+const submit = () => {
+    return axios.post(route('api-keys.store'), form.value)
+        .then(({data}) => {
+            token.value = data.token
+        })
+        .catch(({response}) => {
+            errors.value.name = response?.data?.errors?.name[0] ?? "Unknown error occurred"
+        })
+        .finally(() => {
+            router.reload({only: [
+                'apiKeys',
+            ]})
+        })
+}
+
+const close = () => {
+    open.value = false
+}
+</script>
+
+<template>
+    <Dialog v-model:open="open">
+        <DialogTrigger>
+            <slot/>
+        </DialogTrigger>
+        <DialogContent>
+            <DialogHeader>
+                <DialogTitle>Create API Key</DialogTitle>
+                <DialogDescription>
+                    Create a new API key to be used for programmatic access to ShotShare
+                </DialogDescription>
+            </DialogHeader>
+
+            <form v-if="!token" class="space-y-4" @submit.prevent="submit">
+                <FormItem>
+                    <FormLabel
+                        for="name"
+                        :invalid="Boolean(errors.name)">
+                        Name
+                    </FormLabel>
+
+                    <FormControl>
+                        <Input
+                            v-model="form.name"
+                            id="name"
+                            type="text"
+                            placeholder="a descriptive name"
+                            @change="errors.name = null" />
+                    </FormControl>
+
+                    <FormDescription>
+                        Give the API key a recognizable label
+                    </FormDescription>
+
+                    <FormMessage v-if="errors.name">
+                        {{ errors.name }}
+                    </FormMessage>
+                </FormItem>
+            </form>
+
+            <div v-else class="space-y-4">
+                <div>
+                    <Label for="api_key" class="mb-2">Token</Label>
+                    <div class="relative">
+                        <Input id="api_key" :model-value="token" disabled/>
+                        <UseClipboard
+                            v-slot="{ copy, copied }"
+                            :source="token">
+                            <Button
+                                @click.prevent="copy()"
+                                class="absolute right-0 top-0 bottom-0 text-accent hover:text-primary"
+                                variant="ghost">
+                                <CheckIcon v-if="copied" class="h-5 w-5 text-green-500" />
+                                <ClipboardIcon v-else class="h-5 w-5" />
+                            </Button>
+                        </UseClipboard>
+                    </div>
+                </div>
+                <p class="font-semibold text-yellow-300">
+                    Ensure you save this key somewhere as it will only be displayed this one time.
+                </p>
+            </div>
+
+            <DialogFooter v-if="!token">
+                <Button variant="outline" @click.prevent="close">Cancel</Button>
+                <Button type="submit" @click.prevent="submit">Create API Key</Button>
+            </DialogFooter>
+
+            <DialogFooter v-else>
+                <Button @click.prevent="close">I have copied my key</Button>
+            </DialogFooter>
+        </DialogContent>
+    </Dialog>
+</template>

--- a/resources/js/Pages/Shots/Partials/ShotDetails.vue
+++ b/resources/js/Pages/Shots/Partials/ShotDetails.vue
@@ -23,7 +23,7 @@ const reactToShot = (shotId, reaction) => {
         router.reload({ only: [
             'reaction',
             'reactionCounts',
-        ] })
+        ]})
     })
 }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,6 @@
 <?php
 
-use Illuminate\Http\Request;
+use App\Http\Controllers\UploadController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -14,6 +14,6 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
-    return $request->user();
+Route::middleware('auth:sanctum')->group(function () {
+    Route::post('/upload', UploadController::class)->name('upload');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,7 +42,7 @@ Route::prefix('shots')
 Route::prefix('api-keys')
     ->name('api-keys.')
     ->controller(ApiKeyController::class)
-    ->group(function() {
+    ->group(function () {
         Route::post('', 'store')->name('store');
         Route::delete('{id}', 'destroy')->name('destroy');
     });

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\ApiKeyController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\ShotController;
 use App\Http\Controllers\UploadController;
@@ -24,7 +25,6 @@ Route::get('/', function () {
 
 Route::prefix('shots')
     ->name('shots.')
-    ->prefix('shots')
     ->controller(ShotController::class)
     ->group(function () {
         Route::get('', 'index')
@@ -37,6 +37,14 @@ Route::prefix('shots')
         Route::post('{id}/react', 'react')
             ->name('react')
             ->middleware('feature:reactions');
+    });
+
+Route::prefix('api-keys')
+    ->name('api-keys.')
+    ->controller(ApiKeyController::class)
+    ->group(function() {
+        Route::post('', 'store')->name('store');
+        Route::delete('{id}', 'destroy')->name('destroy');
     });
 
 Route::post('/upload', UploadController::class)

--- a/shotshare.sxcu
+++ b/shotshare.sxcu
@@ -1,0 +1,17 @@
+{
+  "Version": "15.0.0",
+  "Name": "ShotShare",
+  "DestinationType": "ImageUploader",
+  "RequestMethod": "POST",
+  "RequestURL": "{Your ShotShare URL}/api/upload",
+  "Headers": {
+    "Authorization": "Bearer {Your API Key}",
+    "Accept": "application/json"
+  },
+  "Body": "MultipartFormData",
+  "Arguments": {
+    "images[0]": null
+  },
+  "FileFormName": "images[0]",
+  "URL": "{json:data.link}"
+}

--- a/tests/Unit/Http/Controllers/ApiKeyControllerTest.php
+++ b/tests/Unit/Http/Controllers/ApiKeyControllerTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Unit\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ApiKeyControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+    }
+
+    public function test_it_creates_api_keys()
+    {
+        $response = $this->actingAs($this->user)
+            ->post(route('api-keys.store'), ['name' => $name = 'test'])
+            ->assertOk();
+
+        $token = $this->user->tokens->first();
+
+        $this->assertEquals($name, $token->name, 'it sets the desired name');
+        $this->assertEquals($token->token, hash('sha256', $response->getOriginalContent()['token']), 'it returns correct token value');
+    }
+
+    public function test_it_deletes_api_keys()
+    {
+        $this->user->createToken('test');
+        $token = $this->user->tokens()->first();
+
+        $this->actingAs($this->user)
+            ->delete(route('api-keys.destroy', $token->id))
+            ->assertNoContent();
+
+        $this->assertNull($token->fresh(), 'it deletes token');
+    }
+}

--- a/tests/Unit/Http/Controllers/UploadControllerTest.php
+++ b/tests/Unit/Http/Controllers/UploadControllerTest.php
@@ -48,4 +48,27 @@ class UploadControllerTest extends TestCase
         $this->assertNotNull($parentRecord, 'it created parent record');
         $this->assertNotNull($childRecord, 'it created child record');
     }
+
+    public function test_it_returns_json()
+    {
+        Storage::fake();
+
+        $image = UploadedFile::fake()->image('fileA.jpg');
+
+        $response = $this
+            ->actingAs($this->user)
+            ->post(route('api.upload'), [
+                'images' => [$image],
+            ], [
+                'accept' => 'application/json',
+            ]);
+
+        $shot = Shot::first();
+
+        $this->assertEquals([
+            'data' => [
+                'link' => $shot->links['url'],
+            ],
+        ], json_decode($response->getContent(), true), 'it returns json');
+    }
 }


### PR DESCRIPTION
- Adds API key (Sanctum support)
- Adds API key management
- Adds API support for the upload route
- Creates example ShareX configuration file

All these screenshots are from the profile screen

![image](https://github.com/mdshack/shotshare/assets/37004539/a5f6f270-ce42-4fd6-811e-751e403cf787)
**List of existing API keys**

![image](https://github.com/mdshack/shotshare/assets/37004539/3fa160a7-3a96-496b-9885-eb203065e874)
**Delete API key dialog**

![image](https://github.com/mdshack/shotshare/assets/37004539/c1280fba-d939-4bdf-8573-906b57aad2de)
**Create API key dialog**

![image](https://github.com/mdshack/shotshare/assets/37004539/bd8b2a52-3f44-45ad-81e7-f8dd2b1d19f5)
**Post create/confirmation screen**
