### PR TITLE
feat: add opengraph markup to enable rich previews in messaging apps

### DIFF
--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -4,6 +4,14 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
+        <meta property="og:url" content="{{$page['props']['shot']['links']['url']}}">
+        <meta property="og:title" content="{{$page['props']['shot']['name']}}" />
+        <meta property="og:description" content="An image shared on ShotShare" />
+
+        <?php if (isset($page['props']['shot']['links']['asset_url'])): ?>
+        <meta property="og:image" content="{{$page['props']['shot']['links']['asset_url']}}"/>
+        <?php endif; ?>
+
         <title inertia>{{ config('app.name', 'ShotShare') }}</title>
 
         <!-- Fonts -->

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -11,7 +11,9 @@
         <meta property="og:description" content="An image shared on ShotShare" />
 
         <?php if (isset($page['props']['shot']['links']['asset_url'])): ?>
+
         <meta property="og:image" content="{{$page['props']['shot']['links']['asset_url']}}"/>
+
         <?php endif; ?>
 
         <?php endif; ?>

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -4,12 +4,16 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
+        <?php if (isset($page['props']['shot'])):?>
+
         <meta property="og:url" content="{{$page['props']['shot']['links']['url']}}">
         <meta property="og:title" content="{{$page['props']['shot']['name']}}" />
         <meta property="og:description" content="An image shared on ShotShare" />
 
         <?php if (isset($page['props']['shot']['links']['asset_url'])): ?>
         <meta property="og:image" content="{{$page['props']['shot']['links']['asset_url']}}"/>
+        <?php endif; ?>
+
         <?php endif; ?>
 
         <title inertia>{{ config('app.name', 'ShotShare') }}</title>


### PR DESCRIPTION
This adds the markup required to implement https://github.com/mdshack/shotshare/issues/46

I don't have discord, but have tested that this results in a preview in

Signal:

![Screenshot_20240714_104832](https://github.com/user-attachments/assets/b01b65bc-6dd5-4be6-b608-8094f5fa771d)

Slack:

![image](https://github.com/user-attachments/assets/1c51bc0f-7860-438c-92a5-ab76188b5759)

Mastodon

![Screenshot_20240714_105153](https://github.com/user-attachments/assets/13288faf-8cda-4f73-a3f0-b52bed9a99b4)


