### PR TITLE
fix: correct .ini path so that environment variable overrides are honoured

### DIFF
--- a/.docker/init/00_configure_php
+++ b/.docker/init/00_configure_php
@@ -2,7 +2,7 @@
 
 # PHP Configuration Overrides
 
-echo "memory_limit = ${PHP_MEMORY_LIMIT:-128M}" >> /etc/php.d/environment.ini
-echo "upload_max_filesize = ${PHP_UPLOAD_MAX_FILESIZE:-2M}" >> /etc/php.d/environment.ini
-echo "max_file_uploads = ${PHP_MAX_UPLOADS:-20}" >> /etc/php.d/environment.ini
-echo "post_max_size = ${PHP_POST_MAX_SIZE:-8M}" >> /etc/php.d/environment.ini
+echo "memory_limit = ${PHP_MEMORY_LIMIT:-128M}" >> /usr/local/etc/php/conf.d/environment.ini
+echo "upload_max_filesize = ${PHP_UPLOAD_MAX_FILESIZE:-2M}" >> /usr/local/etc/php/conf.d/environment.ini
+echo "max_file_uploads = ${PHP_MAX_UPLOADS:-20}" >> /usr/local/etc/php/conf.d/environment.ini
+echo "post_max_size = ${PHP_POST_MAX_SIZE:-8M}" >> /usr/local/etc/php/conf.d/environment.ini


### PR DESCRIPTION
The current logic reads environment variables and writes them into `/etc/php.d/environment.ini`.

The entrypoint then passes `php-fpm` this the parent directory as a config dir:
```sh
php-fpm -c /etc/php.d/
```

However, `php-fpm` will **not** read `environment.ini`. You can confirm this by setting the variables high and creating a large "image" to upload:

```
dd if=/dev/random of=test.jpg bs=1M count=15
```

If you hit the UI, signup and try and upload, you'll receive a PHP error message which includes

> exceeds the limit of 8388608 bytes

The limit is still at 8M.



Checking `php-fpm --help` shows that it's looking for a file called `php.ini`.

```text
php-fpm --help
Usage: php [-n] [-e] [-h] [-i] [-m] [-v] [-t] [-p <prefix>] [-g <pid>] [-c <file>] [-d foo[=bar]] [-y <file>] [-D] [-F [-O]]
  -c <path>|<file> Look for php.ini file in this directory
```

Adjusting the init script to instead write to `php.ini` works, but comes at the cost of losing any other settings which have been configured in `/usr/local/etc/php/php.ini-production`

Because the settings generated by the init script are additive, it probably makes more sense to drop them into `/usr/local/etc/php/conf.d/`, so that is what this PR does


